### PR TITLE
Feature compose pattern

### DIFF
--- a/graphix/pattern.py
+++ b/graphix/pattern.py
@@ -168,7 +168,7 @@ class Pattern:
         self.extend(cmds)
 
     def compose(self, other: Pattern, mapping: Mapping[int, int]) -> tuple[Pattern, dict[int, int]]:
-        """Compose two patterns"""
+        """Compose two patterns."""
 
         def get_nodes(p: Pattern) -> set[int]:  # should we add this as a property of pattern?
             nodes: set[int]

--- a/graphix/pattern.py
+++ b/graphix/pattern.py
@@ -166,6 +166,56 @@ class Pattern:
         self.clear()
         self.extend(cmds)
 
+    def compose(self, other: Pattern, mapping: Mapping[int, int]) -> tuple[Pattern, dict[int, int]]:
+        """Compose two patterns"""
+
+        def get_nodes(p: Pattern) -> set[int]:  # should we add this as a property of pattern?
+            nodes: set[int]
+            nodes = set()
+            for c in p:
+                nodes.update(c.nodes) if c.kind.name == 'E' else nodes.add(c.node)  # Maybe all commands should have an attribute `nodes` (Iterable) even if they act on a single qubit or would that be misleading ?
+            return nodes
+
+        nodes_p1 = get_nodes(self)
+        nodes_p2 = get_nodes(other)
+
+        if not mapping.keys() <= nodes_p2:
+            raise ValueError("Keys of `mapping` must correspond to the nodes of `other`")
+
+        if len(mapping.values()) != len(set(mapping.values())):
+            raise ValueError("Values of `mapping` contain duplicates.")
+
+        if mapping.keys() & nodes_p1 - set(self.__output_nodes):
+            raise ValueError("Values of `mapping` must not contain measured nodes of pattern `self`")
+
+        for k, v in mapping.items():
+            if v in self.__output_nodes and k not in other.input_nodes:
+                raise ValueError(f"Mapping {k} -> {v} is not valid. {v} is an output of pattern `self` but {k} is not an input of pattern `other`.")
+
+        # The following lines are copy-pasted from OpenGraph.compose -> could design be improved?
+        shift = max(*nodes_p1, *mapping.values()) + 1
+        mapping_sequential = {
+            node: i for i, node in enumerate(sorted(nodes_p2 - mapping.keys()), start=shift)
+        }  # assigns new labels to nodes in other not specified in mapping
+
+        mapping_complete = {**mapping, **mapping_sequential}
+
+        inputs = self.__input_nodes + [mapping_complete[n] for n in other.input_nodes if n not in mapping]
+        outputs = [n for n in self.__output_nodes if n not in mapping.values()] + [mapping_complete[n] for n in other.output_nodes]
+
+        def update_command(cmd: Command) -> Command:
+            cmd_new = deepcopy(cmd)
+            if cmd.kind.name == 'E':
+                cmd_new.nodes = tuple(mapping_complete[i] for i in cmd.nodes)
+            else:
+                cmd_new.node = mapping_complete[cmd.node]
+
+            return cmd_new
+
+        seq = [update_command(c) for c in p[::-1]] + self.__seq
+
+        return Pattern(input_nodes=inputs, output_nodes=outputs, cmds=seq), mapping_complete
+
     @property
     def input_nodes(self) -> list[int]:
         """List input nodes."""

--- a/graphix/pattern.py
+++ b/graphix/pattern.py
@@ -176,14 +176,8 @@ class Pattern:
             for c in p:
                 with contextlib.suppress(AttributeError):
                     nodes.add(c.node)
-                    with contextlib.suppress(AttributeError):
-                        nodes.update(c.nodes)
-
-                # Alternatively:  ...but EAFP ?
-                # if hasattr(c, 'node'):
-                #     nodes.add(c.node)
-                # elif hasattr(c, 'nodes'):
-                #     nodes.update(c.nodes)
+                with contextlib.suppress(AttributeError):
+                    nodes.update(c.nodes)
 
             return nodes
 
@@ -222,16 +216,18 @@ class Pattern:
         def update_command(cmd: Command) -> Command:
             cmd_new = deepcopy(cmd)
 
-            with contextlib.suppress(AttributeError):
-                cmd_new.node = mapping_complete[cmd.node]  # All commands except E and T
-                with contextlib.suppress(AttributeError):
-                    cmd_new.nodes = tuple(mapping_complete[i] for i in cmd.nodes)  # Only E
+            # To ensure compatibility in case a new command is added.
+            assert cmd.kind in {CommandKind.N, CommandKind.M, CommandKind.E, CommandKind.C, CommandKind.X, CommandKind.Z, CommandKind.S, CommandKind.T}
 
-            with contextlib.suppress(AttributeError):
-                cmd_new.domain = {mapping_complete[i] for i in cmd.domain}  # X, Z, S commands
-                with contextlib.suppress(AttributeError):
-                    cmd_new.s_domain = {mapping_complete[i] for i in cmd.s_domain}  # Only M
+            if cmd.kind is CommandKind.E:
+                cmd_new.nodes = tuple(mapping_complete[i] for i in cmd.nodes)
+            elif cmd.kind is not CommandKind.E:
+                cmd_new.node = mapping_complete[cmd.node]
+                if cmd.kind is CommandKind.M:
+                    cmd_new.s_domain = {mapping_complete[i] for i in cmd.s_domain}
                     cmd_new.t_domain = {mapping_complete[i] for i in cmd.t_domain}
+                elif cmd.kind in {CommandKind.X, CommandKind.Z, CommandKind.S}:
+                    cmd_new.domain = {mapping_complete[i] for i in cmd.domain}
 
             return cmd_new
 

--- a/graphix/pattern.py
+++ b/graphix/pattern.py
@@ -29,6 +29,7 @@ from graphix.pretty_print import OutputFormat, pattern_to_str
 from graphix.simulator import PatternSimulator
 from graphix.states import BasicStates
 from graphix.visualization import GraphVisualizer
+import contextlib
 
 if TYPE_CHECKING:
     from collections.abc import Container, Iterable, Iterator, Mapping
@@ -172,8 +173,11 @@ class Pattern:
         def get_nodes(p: Pattern) -> set[int]:  # should we add this as a property of pattern?
             nodes: set[int]
             nodes = set()
-            for c in p:
-                nodes.update(c.nodes) if c.kind.name == 'E' else nodes.add(c.node)  # Maybe all commands should have an attribute `nodes` (Iterable) even if they act on a single qubit or would that be misleading ?
+            for c in p:  # Ruff complains if putting try/except statements inside the loop (PERF203)
+                if hasattr(c, 'node'):
+                    nodes.add(c.node)
+                elif hasattr(c, 'nodes'):
+                    nodes.update(c.nodes)
             return nodes
 
         nodes_p1 = get_nodes(self)
@@ -185,7 +189,7 @@ class Pattern:
         if len(mapping.values()) != len(set(mapping.values())):
             raise ValueError("Values of `mapping` contain duplicates.")
 
-        if mapping.keys() & nodes_p1 - set(self.__output_nodes):
+        if set(mapping.values()) & nodes_p1 - set(self.__output_nodes):
             raise ValueError("Values of `mapping` must not contain measured nodes of pattern `self`")
 
         for k, v in mapping.items():
@@ -200,19 +204,33 @@ class Pattern:
 
         mapping_complete = {**mapping, **mapping_sequential}
 
-        inputs = self.__input_nodes + [mapping_complete[n] for n in other.input_nodes if n not in mapping]
-        outputs = [n for n in self.__output_nodes if n not in mapping.values()] + [mapping_complete[n] for n in other.output_nodes]
+        mapped_inputs = [mapping_complete[n] for n in other.input_nodes]
+        mapped_outputs = [mapping_complete[n] for n in other.output_nodes]
+
+        merged = set(mapping_complete.values()) & set(self.__output_nodes)
+
+        inputs = self.__input_nodes + [n for n in mapped_inputs if n not in merged]
+        outputs = [n for n in self.__output_nodes if n not in merged] + mapped_outputs
 
         def update_command(cmd: Command) -> Command:
             cmd_new = deepcopy(cmd)
-            if cmd.kind.name == 'E':
-                cmd_new.nodes = tuple(mapping_complete[i] for i in cmd.nodes)
-            else:
-                cmd_new.node = mapping_complete[cmd.node]
+
+            try:
+                cmd_new.node = mapping_complete[cmd.node]  # All commands except E and T
+            except AttributeError:
+                with contextlib.suppress(AttributeError):
+                    cmd_new.nodes = tuple(mapping_complete[i] for i in cmd.nodes)  # Only E
+
+            try:
+                cmd_new.domain = {mapping_complete[i] for i in cmd.domain}  # X, Z, S commands
+            except AttributeError:
+                with contextlib.suppress(AttributeError):
+                    cmd_new.s_domain = {mapping_complete[i] for i in cmd.s_domain}  # Only M
+                    cmd_new.t_domain = {mapping_complete[i] for i in cmd.t_domain}
 
             return cmd_new
 
-        seq = [update_command(c) for c in p[::-1]] + self.__seq
+        seq = self.__seq + [update_command(c) for c in other]
 
         return Pattern(input_nodes=inputs, output_nodes=outputs, cmds=seq), mapping_complete
 

--- a/graphix/pattern.py
+++ b/graphix/pattern.py
@@ -185,19 +185,19 @@ class Pattern:
         nodes_p2 = get_nodes(other)
 
         if not mapping.keys() <= nodes_p2:
-            raise ValueError("Keys of `mapping` must correspond to the nodes of `other`")
+            raise ValueError("Keys of `mapping` must correspond to the nodes of `other`.")
 
         if len(mapping.values()) != len(set(mapping.values())):
             raise ValueError("Values of `mapping` contain duplicates.")
 
         if set(mapping.values()) & nodes_p1 - set(self.__output_nodes):
-            raise ValueError("Values of `mapping` must not contain measured nodes of pattern `self`")
+            raise ValueError("Values of `mapping` must not contain measured nodes of pattern `self`.")
 
         for k, v in mapping.items():
             if v in self.__output_nodes and k not in other.input_nodes:
                 raise ValueError(f"Mapping {k} -> {v} is not valid. {v} is an output of pattern `self` but {k} is not an input of pattern `other`.")
 
-        # The following lines are copy-pasted from OpenGraph.compose -> could design be improved?
+        # The following lines are taken from OpenGraph.compose -> could design be improved?
         shift = max(*nodes_p1, *mapping.values()) + 1
         mapping_sequential = {
             node: i for i, node in enumerate(sorted(nodes_p2 - mapping.keys()), start=shift)

--- a/graphix/pattern.py
+++ b/graphix/pattern.py
@@ -195,7 +195,7 @@ class Pattern:
             - :math:`U \cap O_1^c = \emptyset`. If :math:`v \in O_1`, then :math:`k \in I_2`, otherwise an error is raised.
 
         The returned pattern follows this convention:
-        - Nodes of pattern `other` not specified in `mapping` (i.e., :math:`i \in V_2 \cap K^c`) are relabelled in ascending order.
+        - Nodes of pattern `other` not specified in `mapping` (i.e., :math:`V_2 \cap K^c`) are relabelled in ascending order.
         - The sequence of the resulting pattern is :math:`S = S_2 S_1`, where nodes in :math:`S_2` are relabelled according to `mapping`.
         - :math:`I = I_1 \cup (I_2 \setminus M_2)`.
         - :math:`O = (O_1 \setminus M_1) \cup O_2`.

--- a/graphix/pattern.py
+++ b/graphix/pattern.py
@@ -168,7 +168,40 @@ class Pattern:
         self.extend(cmds)
 
     def compose(self, other: Pattern, mapping: Mapping[int, int]) -> tuple[Pattern, dict[int, int]]:
-        """Compose two patterns."""
+        r"""Compose two patterns by merging subsets of outputs from `self` and a subset of inputs of `other`, and relabeling the nodes of `other` that were not merged.
+
+        Parameters
+        ----------
+        other : Pattern
+            Pattern to be composed with `self`.
+        mapping: Mapping[int, int]
+            Partial relabelling of the nodes in `other`, with `keys` and `values` denoting the old and new node labels, respectively.
+
+        Returns
+        -------
+        p: Pattern
+            composed pattern
+        mapping_complete: dict[int, int]
+            Complete relabelling of the nodes in `other`, with `keys` and `values` denoting the old and new node label, respectively.
+
+        Notes
+        -----
+        Let's denote :math:`(I_j, O_j, V_j, S_j)` the ordered set of inputs and outputs, the computational space and the sequence of commands of pattern :math`P_j`, respectively, with :math:`j = 1` for pattern `self` and :math:`j = 2` for pattern `other`. Let's denote :math:`P` the resulting pattern with :math:`(I, O, V, S)`.
+        Let's denote :math:`K, U` the sets of `keys` and `values` of `mapping`, and :math:`M_1 = O_1 \cap U` and :math:`M_2 = O_2 \cap K` respectively the set of merged outputs and inputs.
+
+        The pattern composition requires that
+        - :math:`K \subseteq V_2`.
+        - For a pair :math:`(k, v) \in (K, U)`
+            - :math:`v` can always satisfy :math:`v \notin V_1`, thereby allowing a custom relabelling.
+            - :math:`U \cap O_1^c = \emptyset`. If :math:`v \in O_1`, then :math:`k \in I_2`, otherwise an error is raised.
+
+        The returned pattern follows this convention:
+        - Nodes of pattern `other` not specified in `mapping` (i.e., :math:`i \in V_2 \cap K^c`) are relabelled in ascending order.
+        - The sequence of the resulting pattern is :math:`S = S_2 S_1`, where nodes in :math:`S_2` are relabelled according to `mapping`.
+        - :math:`I = I_1 \cup (I_2 \setminus M_2)`.
+        - :math:`O = (O_1 \setminus M_1) \cup O_2`.
+        - Input (and, respectively, output) nodes in the returned pattern have the order of the pattern `self` followed by those of the pattern `other`. Merged nodes are removed.
+        """
 
         def get_nodes(p: Pattern) -> set[int]:  # should we add this as a property of pattern?
             nodes: set[int]

--- a/graphix/pattern.py
+++ b/graphix/pattern.py
@@ -29,7 +29,6 @@ from graphix.pretty_print import OutputFormat, pattern_to_str
 from graphix.simulator import PatternSimulator
 from graphix.states import BasicStates
 from graphix.visualization import GraphVisualizer
-import contextlib
 
 if TYPE_CHECKING:
     from collections.abc import Container, Iterable, Iterator, Mapping
@@ -206,11 +205,23 @@ class Pattern:
         def get_nodes(p: Pattern) -> set[int]:  # should we add this as a property of pattern?
             nodes: set[int]
             nodes = set()
-            for c in p:
-                with contextlib.suppress(AttributeError):
-                    nodes.add(c.node)
-                with contextlib.suppress(AttributeError):
-                    nodes.update(c.nodes)
+            for cmd in p:
+                # To ensure compatibility in case a new command is added.
+                assert cmd.kind in {
+                    CommandKind.N,
+                    CommandKind.M,
+                    CommandKind.E,
+                    CommandKind.C,
+                    CommandKind.X,
+                    CommandKind.Z,
+                    CommandKind.S,
+                    CommandKind.T,
+                }
+
+                if cmd.kind is CommandKind.E:
+                    nodes.update(cmd.nodes)
+                elif cmd.kind is not CommandKind.T:
+                    nodes.add(cmd.node)
 
             return nodes
 
@@ -228,7 +239,9 @@ class Pattern:
 
         for k, v in mapping.items():
             if v in self.__output_nodes and k not in other.input_nodes:
-                raise ValueError(f"Mapping {k} -> {v} is not valid. {v} is an output of pattern `self` but {k} is not an input of pattern `other`.")
+                raise ValueError(
+                    f"Mapping {k} -> {v} is not valid. {v} is an output of pattern `self` but {k} is not an input of pattern `other`."
+                )
 
         # The following lines are taken from OpenGraph.compose -> could design be improved?
         shift = max(*nodes_p1, *mapping.values()) + 1
@@ -250,17 +263,26 @@ class Pattern:
             cmd_new = deepcopy(cmd)
 
             # To ensure compatibility in case a new command is added.
-            assert cmd.kind in {CommandKind.N, CommandKind.M, CommandKind.E, CommandKind.C, CommandKind.X, CommandKind.Z, CommandKind.S, CommandKind.T}
+            assert cmd.kind in {
+                CommandKind.N,
+                CommandKind.M,
+                CommandKind.E,
+                CommandKind.C,
+                CommandKind.X,
+                CommandKind.Z,
+                CommandKind.S,
+                CommandKind.T,
+            }
 
-            if cmd.kind is CommandKind.E:
-                cmd_new.nodes = tuple(mapping_complete[i] for i in cmd.nodes)
-            elif cmd.kind is not CommandKind.E:
-                cmd_new.node = mapping_complete[cmd.node]
-                if cmd.kind is CommandKind.M:
-                    cmd_new.s_domain = {mapping_complete[i] for i in cmd.s_domain}
-                    cmd_new.t_domain = {mapping_complete[i] for i in cmd.t_domain}
-                elif cmd.kind in {CommandKind.X, CommandKind.Z, CommandKind.S}:
-                    cmd_new.domain = {mapping_complete[i] for i in cmd.domain}
+            if cmd_new.kind is CommandKind.E:
+                cmd_new.nodes = tuple(mapping_complete[i] for i in cmd_new.nodes)
+            elif cmd_new.kind is not CommandKind.T:
+                cmd_new.node = mapping_complete[cmd_new.node]
+                if cmd_new.kind is CommandKind.M:
+                    cmd_new.s_domain = {mapping_complete[i] for i in cmd_new.s_domain}
+                    cmd_new.t_domain = {mapping_complete[i] for i in cmd_new.t_domain}
+                elif cmd_new.kind in {CommandKind.X, CommandKind.Z, CommandKind.S}:
+                    cmd_new.domain = {mapping_complete[i] for i in cmd_new.domain}
 
             return cmd_new
 

--- a/graphix/pattern.py
+++ b/graphix/pattern.py
@@ -173,11 +173,18 @@ class Pattern:
         def get_nodes(p: Pattern) -> set[int]:  # should we add this as a property of pattern?
             nodes: set[int]
             nodes = set()
-            for c in p:  # Ruff complains if putting try/except statements inside the loop (PERF203)
-                if hasattr(c, 'node'):
+            for c in p:
+                with contextlib.suppress(AttributeError):
                     nodes.add(c.node)
-                elif hasattr(c, 'nodes'):
-                    nodes.update(c.nodes)
+                    with contextlib.suppress(AttributeError):
+                        nodes.update(c.nodes)
+
+                # Alternatively:  ...but EAFP ?
+                # if hasattr(c, 'node'):
+                #     nodes.add(c.node)
+                # elif hasattr(c, 'nodes'):
+                #     nodes.update(c.nodes)
+
             return nodes
 
         nodes_p1 = get_nodes(self)
@@ -215,15 +222,13 @@ class Pattern:
         def update_command(cmd: Command) -> Command:
             cmd_new = deepcopy(cmd)
 
-            try:
+            with contextlib.suppress(AttributeError):
                 cmd_new.node = mapping_complete[cmd.node]  # All commands except E and T
-            except AttributeError:
                 with contextlib.suppress(AttributeError):
                     cmd_new.nodes = tuple(mapping_complete[i] for i in cmd.nodes)  # Only E
 
-            try:
+            with contextlib.suppress(AttributeError):
                 cmd_new.domain = {mapping_complete[i] for i in cmd.domain}  # X, Z, S commands
-            except AttributeError:
                 with contextlib.suppress(AttributeError):
                     cmd_new.s_domain = {mapping_complete[i] for i in cmd.s_domain}  # Only M
                     cmd_new.t_domain = {mapping_complete[i] for i in cmd.t_domain}

--- a/tests/test_pattern.py
+++ b/tests/test_pattern.py
@@ -427,29 +427,7 @@ class TestPattern:
         state_p = pattern.simulate_pattern()
         assert np.abs(np.dot(state_p.flatten().conjugate(), state_ref.flatten())) == pytest.approx(1)
 
-    # def test_compose_1(self) -> None:
-    #     i1 = [1, 4]
-    #     o1 = [4]
-    #     cmds1 = [N(0), N(2), N(3), E((1, 2)), E((0, 4)), M(0), M(1), M(2), M(3, t_domain={1}, s_domain={2}), Z(4, {0}), X(4, {3, 1})]
-    #     p1 = Pattern(cmds=cmds1, input_nodes=i1, output_nodes=o1)
-
-    #     i2 = [0, 3]
-    #     o2 = [3]
-    #     cmds2 = [N(1), N(2), M(1), M(2), M(0, t_domain={1}, s_domain={2}), Z(3, {1, 0}), X(3, {2})]
-    #     p2 = Pattern(cmds=cmds2, input_nodes=i2, output_nodes=o2)
-
-    #     mapping = {0: 4, 3: 100}
-    #     pc, mapping_complete = p1.compose(other=p2, mapping=mapping)
-
-    #     i = [1, 4, 100]
-    #     o = [100]
-    #     cmds = [N(0), N(2), N(3), E((1, 2)), E((0, 4)), M(0), M(1), M(2), M(3, t_domain={1}, s_domain={2}), Z(4, {0}), X(4, {3, 1}), N(102), N(101), M(102), M(101), M(4, t_domain={101}, s_domain={102}), Z(100, {4, 101}), X(100, {102})]
-    #     p = Pattern(cmds=cmds, input_nodes=i, output_nodes=o)
-
-    #     assert p == pc
-    #     assert mapping_complete == {0: 4, 3: 100, 1: 101, 2: 102}
-
-    def test_compose(self) -> None:
+    def test_compose_1(self) -> None:
         i1_lst = [0]
         o1_lst = [1]
         cmds1 = [N(1), E((0, 1)), M(0), Z(1, {0}), X(1, {0})]
@@ -470,6 +448,41 @@ class TestPattern:
 
         assert pc == p
         assert mapping_c == {0: 1, 2: 5}
+
+        with pytest.raises(ValueError, match=r"Keys of `mapping` must correspond to the nodes of `other`."):
+            p1.compose(p2, mapping={0: 1, 2: 5, 1: 2})
+
+        with pytest.raises(ValueError, match=r"Values of `mapping` contain duplicates."):
+            p1.compose(p2, mapping={0: 1, 2: 1})
+
+        with pytest.raises(ValueError, match=r"Values of `mapping` must not contain measured nodes of pattern `self`."):
+            p1.compose(p2, mapping={0: 1, 2: 0})
+
+        with pytest.raises(ValueError, match=r"Mapping 2 -> 1 is not valid. 1 is an output of pattern `self` but 2 is not an input of pattern `other`."):
+            p1.compose(p2, mapping={2: 1})
+
+
+    def test_compose_2(self) -> None:
+        i1 = [1, 4]
+        o1 = [4]
+        cmds1 = [N(0), N(2), N(3), E((1, 2)), E((0, 4)), M(0), M(1), M(2), M(3, t_domain={1}, s_domain={2}), Z(4, {0}), X(4, {3, 1})]
+        p1 = Pattern(cmds=cmds1, input_nodes=i1, output_nodes=o1)
+
+        i2 = [0, 3]
+        o2 = [3]
+        cmds2 = [N(1), N(2), M(1), M(2), M(0, t_domain={1}, s_domain={2}), Z(3, {1, 0}), X(3, {2})]
+        p2 = Pattern(cmds=cmds2, input_nodes=i2, output_nodes=o2)
+
+        mapping = {0: 4, 3: 100}
+        pc, mapping_complete = p1.compose(other=p2, mapping=mapping)
+
+        i = [1, 4, 100]
+        o = [100]
+        cmds = [N(0), N(2), N(3), E((1, 2)), E((0, 4)), M(0), M(1), M(2), M(3, t_domain={1}, s_domain={2}), Z(4, {0}), X(4, {3, 1}), N(101), N(102), M(101), M(102), M(4, t_domain={101}, s_domain={102}), Z(100, {4, 101}), X(100, {102})]
+        p = Pattern(cmds=cmds, input_nodes=i, output_nodes=o)
+
+        assert p == pc
+        assert mapping_complete == {0: 4, 3: 100, 1: 101, 2: 102}
 
 
 def cp(circuit: Circuit, theta: float, control: int, target: int) -> None:

--- a/tests/test_pattern.py
+++ b/tests/test_pattern.py
@@ -427,6 +427,8 @@ class TestPattern:
         state_p = pattern.simulate_pattern()
         assert np.abs(np.dot(state_p.flatten().conjugate(), state_ref.flatten())) == pytest.approx(1)
 
+    #def test_compose(self) -> None:
+
 
 def cp(circuit: Circuit, theta: float, control: int, target: int) -> None:
     """Controlled rotation gate, decomposed."""  # noqa: D401

--- a/tests/test_pattern.py
+++ b/tests/test_pattern.py
@@ -458,14 +458,28 @@ class TestPattern:
         with pytest.raises(ValueError, match=r"Values of `mapping` must not contain measured nodes of pattern `self`."):
             p1.compose(p2, mapping={0: 1, 2: 0})
 
-        with pytest.raises(ValueError, match=r"Mapping 2 -> 1 is not valid. 1 is an output of pattern `self` but 2 is not an input of pattern `other`."):
+        with pytest.raises(
+            ValueError,
+            match=r"Mapping 2 -> 1 is not valid. 1 is an output of pattern `self` but 2 is not an input of pattern `other`.",
+        ):
             p1.compose(p2, mapping={2: 1})
-
 
     def test_compose_2(self) -> None:
         i1 = [1, 4]
         o1 = [4]
-        cmds1 = [N(0), N(2), N(3), E((1, 2)), E((0, 4)), M(0), M(1), M(2), M(3, t_domain={1}, s_domain={2}), Z(4, {0}), X(4, {3, 1})]
+        cmds1 = [
+            N(0),
+            N(2),
+            N(3),
+            E((1, 2)),
+            E((0, 4)),
+            M(0),
+            M(1),
+            M(2),
+            M(3, t_domain={1}, s_domain={2}),
+            Z(4, {0}),
+            X(4, {3, 1}),
+        ]
         p1 = Pattern(cmds=cmds1, input_nodes=i1, output_nodes=o1)
 
         i2 = [0, 3]
@@ -478,7 +492,26 @@ class TestPattern:
 
         i = [1, 4, 100]
         o = [100]
-        cmds = [N(0), N(2), N(3), E((1, 2)), E((0, 4)), M(0), M(1), M(2), M(3, t_domain={1}, s_domain={2}), Z(4, {0}), X(4, {3, 1}), N(101), N(102), M(101), M(102), M(4, t_domain={101}, s_domain={102}), Z(100, {4, 101}), X(100, {102})]
+        cmds = [
+            N(0),
+            N(2),
+            N(3),
+            E((1, 2)),
+            E((0, 4)),
+            M(0),
+            M(1),
+            M(2),
+            M(3, t_domain={1}, s_domain={2}),
+            Z(4, {0}),
+            X(4, {3, 1}),
+            N(101),
+            N(102),
+            M(101),
+            M(102),
+            M(4, t_domain={101}, s_domain={102}),
+            Z(100, {4, 101}),
+            X(100, {102}),
+        ]
         p = Pattern(cmds=cmds, input_nodes=i, output_nodes=o)
 
         assert p == pc

--- a/tests/test_pattern.py
+++ b/tests/test_pattern.py
@@ -427,7 +427,12 @@ class TestPattern:
         state_p = pattern.simulate_pattern()
         assert np.abs(np.dot(state_p.flatten().conjugate(), state_ref.flatten())) == pytest.approx(1)
 
-    #def test_compose(self) -> None:
+    def test_compose(self) -> None:
+        i1 = [1, 4]
+        o1 = [4]
+        cmds1 = [X(4, {1, 3}), Z(4, {0}), M(3, t_domain={1}, s_domain={2}), E((1, 2)), E((0, 4)), M(2), M(1), M(0), N(2), N(3)]
+
+        p1 = Pattern(input_nodes=i1, output_nodes=o1)
 
 
 def cp(circuit: Circuit, theta: float, control: int, target: int) -> None:

--- a/tests/test_pattern.py
+++ b/tests/test_pattern.py
@@ -427,12 +427,49 @@ class TestPattern:
         state_p = pattern.simulate_pattern()
         assert np.abs(np.dot(state_p.flatten().conjugate(), state_ref.flatten())) == pytest.approx(1)
 
-    def test_compose(self) -> None:
-        i1 = [1, 4]
-        o1 = [4]
-        cmds1 = [X(4, {1, 3}), Z(4, {0}), M(3, t_domain={1}, s_domain={2}), E((1, 2)), E((0, 4)), M(2), M(1), M(0), N(2), N(3)]
+    # def test_compose_1(self) -> None:
+    #     i1 = [1, 4]
+    #     o1 = [4]
+    #     cmds1 = [N(0), N(2), N(3), E((1, 2)), E((0, 4)), M(0), M(1), M(2), M(3, t_domain={1}, s_domain={2}), Z(4, {0}), X(4, {3, 1})]
+    #     p1 = Pattern(cmds=cmds1, input_nodes=i1, output_nodes=o1)
 
-        p1 = Pattern(input_nodes=i1, output_nodes=o1)
+    #     i2 = [0, 3]
+    #     o2 = [3]
+    #     cmds2 = [N(1), N(2), M(1), M(2), M(0, t_domain={1}, s_domain={2}), Z(3, {1, 0}), X(3, {2})]
+    #     p2 = Pattern(cmds=cmds2, input_nodes=i2, output_nodes=o2)
+
+    #     mapping = {0: 4, 3: 100}
+    #     pc, mapping_complete = p1.compose(other=p2, mapping=mapping)
+
+    #     i = [1, 4, 100]
+    #     o = [100]
+    #     cmds = [N(0), N(2), N(3), E((1, 2)), E((0, 4)), M(0), M(1), M(2), M(3, t_domain={1}, s_domain={2}), Z(4, {0}), X(4, {3, 1}), N(102), N(101), M(102), M(101), M(4, t_domain={101}, s_domain={102}), Z(100, {4, 101}), X(100, {102})]
+    #     p = Pattern(cmds=cmds, input_nodes=i, output_nodes=o)
+
+    #     assert p == pc
+    #     assert mapping_complete == {0: 4, 3: 100, 1: 101, 2: 102}
+
+    def test_compose(self) -> None:
+        i1_lst = [0]
+        o1_lst = [1]
+        cmds1 = [N(1), E((0, 1)), M(0), Z(1, {0}), X(1, {0})]
+        p1 = Pattern(input_nodes=i1_lst, output_nodes=o1_lst, cmds=cmds1)
+
+        i2_lst = [0]
+        o2_lst = [2]
+        cmds2 = [N(2), E((0, 2)), M(0), Z(2, {0}), X(2, {0})]
+        p2 = Pattern(input_nodes=i2_lst, output_nodes=o2_lst, cmds=cmds2)
+
+        mapping = {0: 1, 2: 5}
+        pc, mapping_c = p1.compose(p2, mapping)
+
+        i_lst = [0]
+        o_lst = [5]
+        cmds = [N(1), E((0, 1)), M(0), Z(1, {0}), X(1, {0}), N(5), E((1, 5)), M(1), Z(5, {1}), X(5, {1})]
+        p = Pattern(input_nodes=i_lst, output_nodes=o_lst, cmds=cmds)
+
+        assert pc == p
+        assert mapping_c == {0: 1, 2: 5}
 
 
 def cp(circuit: Circuit, theta: float, control: int, target: int) -> None:


### PR DESCRIPTION
Introduce new method of `:class: graphix.pattern.Pattern` allowing to combine two patterns. 

Heading:
```python
graphix.pattern.Pattern.compose(self, other: Pattern, mapping: Mapping[int, int]) -> tuple[Pattern, dict[int, int]]:
```

Let's denote $(I_j, O_j, V_j, S_j)$ the ordered set of inputs and outputs, the computational space and the sequence of commands of pattern $P_j$, respectively, with $j =1 (2)$ for pattern `self`(`other`). Let's denote $P$ the resulting pattern with ($I, O, V, S$).
Let's denote $K, U$ the sets of `keys` and `values`of `mapping`.


Expected behavior:

1. $K \subseteq V_2$.
2. For a pair $(k, v) \in (K, U)$ 
	1. $v$ can always satisfy $v \notin V_1$, thereby allowing a custom relabelling. 
	2. $U \cap O_1^c = \emptyset$ (there can't be measured qubits in `values`).  If $v \in O_1$, then $k \in I_2$, otherwise an error is raised.
3. $i \in V_2 \cap K^c$ are relabelled in ascending order.
4. The sequence of the resulting pattern is simply $S = S_2 S_1$, where qubits in $S_2$ are relabelled according to `mapping` (commands of $P_2$ are added _after_ commands of $P_1$).   
5. $I = I_1 \cup (I_2 \setminus M_2)$ where $M_2 = I_2 \cap K$.
6. $O = (O_1 \setminus M_1) \cup O_2$ where $M_1 = O_1 \cap U$.
7. Input (and, respectively, output) nodes in the returned pattern have the order of the pattern `self` followed by those of the pattern `other`. Merged nodes are removed.

Notes:

- (2.2) could be made more general by allowing $k \in V_2$. If $k \notin I_2$, then we would remove the command $N_k$ from $S_2$ in the resulting pattern. However this behavior could be obtained by setting $k$ as in input in $P_2$, when defining the pattern. The design choice above is follows closer the theory (e.g., Danos et al., 2007).
- The new feature `:func: graphix.opengraph.OpenGraph.compose`(see #1 ) is more general. Namely:
	- It allows for merging measured nodes provided that the measuring plane is the same. This is not possible here, because we would need to suppress the measurement command in $P_1$, which might result in commands belonging to $S_1$ depending on an outcome not yet measured.
	- It allows for merging $o \in O_2$ and $i \in I_1$. This behavior in the pattern composition is not consistent with (4.)

Additional comments:
-  `mypy` and `pyright` not passing.
- Inner function `:func: get_nodes` could be implemented as a property of `:class: Pattern`.
