### PR TITLE
Random generator of open graphs with gflow

### DIFF
--- a/graphix/random_objects.py
+++ b/graphix/random_objects.py
@@ -452,7 +452,11 @@ def rand_og_gflow(n: int, n_o: int, rng: Generator, meas_planes: Mapping[int, Pl
 
     Notes
     -----
-    This function implements the PGA algorithm designed by R. Pal.
+    This function implements the PGA algorithm presented in [1].
+
+    References
+    ----------
+    [1] "Generation of random open graph with gflow" Rajarsi Pal, Harold Ollivier, Graphix Workshop, Inria, 2024.
     """
     n_no = n - n_o  # Number of non-output nodes.
     if meas_planes is not None and len(meas_planes) != n_no:
@@ -513,8 +517,8 @@ def _add_vertex(
     # Ensure that we have at least one non-zero coefficient.
     if not np.any(mask):
         mask[rng.integers(len(mask))] = True
-    g_vect = np.bitwise_xor.reduce(kernel[mask], axis=0)  # `g_vect` has shape (k_shift + 1, )
-    c_vect = np.empty(k_shift + 1, dtype=np.uint8)
+    g_vect = np.bitwise_xor.reduce(kernel[mask], axis=0)  # `g_vect` has shape (k_shift, )
+    c_vect = np.empty(k_shift + 1, dtype=np.uint8)  # `c_vect` has shape (k_shift + 1 , )
 
     if plane == Plane.XY:
         c_dot, c_k = 1, 0
@@ -556,6 +560,7 @@ def _generate_rnd_gf2_vec(g: npt.NDArray[np.uint8], c: int, rng: Generator) -> n
             raise ValueError(r"It does not exist an `x` such that  $x \cdot g = c$.")
         return result
 
+    # If the random vector `result` does not fulfil the constraint, it suffices to flip bit `k`, such that `g[k] != 0`.
     if np.bitwise_xor.reduce(result[idx_nonzero]) != c:
         result[rng.choice(idx_nonzero)] ^= 1
 

--- a/tests/test_random_utilities.py
+++ b/tests/test_random_utilities.py
@@ -187,7 +187,7 @@ class TestRandomOpenGraph:
     """A class to group all the tests related to graphix.random_objects.rand_og_flow."""
 
     def test_generate_rnd_gf2_vec(self, fx_rng: Generator) -> None:
-        """Test that returned vector fulfil constraints and are uniformly disrtibuted."""
+        """Test that returned vector fulfils constraints and are uniformly disrtibuted."""
         n_shots = 1000  # number of shots
         g = np.array([1, 0, 0], dtype=np.uint8)
         c = 1
@@ -224,6 +224,6 @@ class TestRandomOpenGraph:
 
         n = 10
         n_o = 4
-        for _ in range(5):
+        for _ in range(10):
             og = randobj.rand_og_gflow(n, n_o, fx_rng)
             assert find_pflow(og) is not None


### PR DESCRIPTION
This commit adds the new function `:func:graphix.random_objects.rand_og_gflow` which generates random open graphs with gflow. In particular:
- Open graphs can have an arbitrary number of nodes `n`.
- Open graphs can have an arbitrary number of outputs `n <= n_o`.
- Measurement planes for the non-output nodes can be fully specified or fully chosen at random. 

The function implements the PGA algorithm [1] which guarantees that any open graph can be generated.

## Additional comments
The module `graphix.random_objects` is not type-safe (although the functions introduced in this PR are). It could also benefit from some cleansing and refactoring, but I guess it's not a priority.

## References
[1] "Generation of random open graph with gflow" Rajarsi Pal, Harold Ollivier, Graphix Workshop, Inria, 2024.
